### PR TITLE
Soft wrap text with fold and tput cols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -44,6 +44,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytes"
@@ -83,7 +89,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -117,7 +123,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -133,7 +139,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -284,6 +290,17 @@ dependencies = [
  "colored",
  "isahc",
  "regex",
+ "termsize",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -346,6 +363,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "once_cell"
@@ -426,7 +449,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -445,6 +468,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
 ]
 
 [[package]]
@@ -498,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -510,6 +551,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
+]
+
+[[package]]
+name = "termsize"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e86d824a8e90f342ad3ef4bd51ef7119a9b681b0cc9f8ee7b2852f02ccd2517"
+dependencies = [
+ "atty",
+ "kernel32-sys",
+ "libc",
+ "termion",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -626,6 +692,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -633,6 +705,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kami"
-#author = "mrfluffy-dev"
+author = "mrfluffy-dev"
 license = "GPL-3.0"
 version = "0.2.0"
 edition = "2021"
@@ -12,3 +12,4 @@ regex = "1.5.6"
 colored = "2.0.0"
 isahc = "1.7.2"
 base64 = "0.13"
+termsize = "0.1.6"

--- a/src/ln/open_text.rs
+++ b/src/ln/open_text.rs
@@ -2,16 +2,11 @@ use std::io::Result;
 use std::process::{Command, ExitStatus, Stdio};
 
 pub fn open_bat() -> Result<ExitStatus> {
-    let terminal_cols_cmd = Command::new("tput").arg("cols").output()?.stdout;
-    let terminal_cols: String = match std::str::from_utf8(&terminal_cols_cmd) {
-        Err(_e) => "80".to_string(),
-        Ok(v) => (v.trim().parse::<i32>().unwrap() - 10).to_string(),
-    };
-
+		let termsize::Size {rows: _, cols} = termsize::get().unwrap();
     let soft_wrap = match Command::new("fold")
         .arg("-s")
         .arg("-w")
-        .arg(terminal_cols)
+        .arg((cols - 9).to_string())
         .arg("/tmp/log_e")
         .stdout(Stdio::piped())
         .spawn()

--- a/src/ln/open_text.rs
+++ b/src/ln/open_text.rs
@@ -1,11 +1,20 @@
 use std::io::Result;
-use std::process::{Command, ExitStatus};
+use std::process::{Command, ExitStatus, Stdio};
 
 pub fn open_bat() -> Result<ExitStatus> {
+    let soft_wrap = match Command::new("fold")
+        .arg("-s")
+        .arg("/tmp/log_e")
+        .stdout(Stdio::piped())
+        .spawn()
+    {
+        Err(why) => panic!("couldn't spawn wc: {}", why),
+        Ok(soft_wrap) => soft_wrap,
+    };
     Command::new("bat")
         .arg("--paging")
         .arg("always")
-        .arg("/tmp/log_e")
+        .stdin(soft_wrap.stdout.unwrap())
         .spawn()?
         .wait()
 }

--- a/src/ln/open_text.rs
+++ b/src/ln/open_text.rs
@@ -2,8 +2,16 @@ use std::io::Result;
 use std::process::{Command, ExitStatus, Stdio};
 
 pub fn open_bat() -> Result<ExitStatus> {
+    let terminal_cols_cmd = Command::new("tput").arg("cols").output()?.stdout;
+    let terminal_cols: String = match std::str::from_utf8(&terminal_cols_cmd) {
+        Err(_e) => "80".to_string(),
+        Ok(v) => (v.trim().parse::<i32>().unwrap() - 10).to_string(),
+    };
+
     let soft_wrap = match Command::new("fold")
         .arg("-s")
+        .arg("-w")
+        .arg(terminal_cols)
         .arg("/tmp/log_e")
         .stdout(Stdio::piped())
         .spawn()
@@ -11,9 +19,12 @@ pub fn open_bat() -> Result<ExitStatus> {
         Err(why) => panic!("couldn't spawn wc: {}", why),
         Ok(soft_wrap) => soft_wrap,
     };
+
     Command::new("bat")
         .arg("--paging")
         .arg("always")
+        .arg("-l")
+        .arg("markdown")
         .stdin(soft_wrap.stdout.unwrap())
         .spawn()?
         .wait()


### PR DESCRIPTION
(Upgrade from #2)

- (feat) Soft wrap text with fold
- (feat) MD syntax for bat|non fixed width for fold

Fold is a gnu utils
Tested with docker image for freebsd test
tput is from ncurses -> probably already existed
Minus the real terminal's width by 10 because of space of the number row

Improve reading experience with softwrap
